### PR TITLE
Fix ordering of different length literal strings. Fixes #8

### DIFF
--- a/src/github.com/ebay/beam/diskview/keys/keys_test.go
+++ b/src/github.com/ebay/beam/diskview/keys/keys_test.go
@@ -210,7 +210,7 @@ func Test_FactKeyBytes(t *testing.T) {
 	}
 	pos := FactKey{Fact: &f, Encoding: rpc.KeyEncodingPOS}
 	assert.Equal(t, []byte("fpos^0000000000000054321^"+
-		"\x01Bob0000000000000000001^"+
+		"\x01Bob\x000000000000000000001^"+
 		"0000000000000012345^"+
 		"0000000000000077777^"+
 		"0000000000000066666"), pos.Bytes())
@@ -218,7 +218,7 @@ func Test_FactKeyBytes(t *testing.T) {
 	spo := FactKey{Fact: &f, Encoding: rpc.KeyEncodingSPO}
 	assert.Equal(t, []byte("fspo^0000000000000012345^"+
 		"0000000000000054321^"+
-		"\x01Bob0000000000000000001^"+
+		"\x01Bob\x000000000000000000001^"+
 		"0000000000000077777^"+
 		"0000000000000066666"), spo.Bytes())
 }

--- a/src/github.com/ebay/beam/query/parser/parsers.go
+++ b/src/github.com/ebay/beam/query/parser/parsers.go
@@ -293,6 +293,15 @@ func termLineParser(termAndSpecificity, termSep, lineSep goparsify.Parser) gopar
 		if disallowed(&spo[0], "Subject") || disallowed(&spo[2], "Object") {
 			return
 		}
+		// Disallow nil's in string literals. This is required to ensure strings
+		// sort correctly in KGObject.
+		if litString, ok := res.Object.(*LiteralString); ok {
+			if strings.IndexByte(litString.Value, 0) >= 0 {
+				s.ErrorHere("string literal to not contain a nil")
+				s.Pos = start
+				return
+			}
+		}
 		r.Result = &res
 	})
 }

--- a/src/github.com/ebay/beam/query/parser/testdata/insert/errors/string_lit_nil_start.res
+++ b/src/github.com/ebay/beam/query/parser/testdata/insert/errors/string_lit_nil_start.res
@@ -1,0 +1,1 @@
+parser: error parsing as legacy query: unable to parse query: line 1 column 37: expected string literal to not contain a nil

--- a/src/github.com/ebay/beam/query/parser/testdata/insert/errors/string_lit_nil_start.tsv
+++ b/src/github.com/ebay/beam/query/parser/testdata/insert/errors/string_lit_nil_start.tsv
@@ -1,0 +1,1 @@
+<Bob> rdfs:label "\u0000Bob's House"

--- a/src/github.com/ebay/beam/query/parser/testdata/insert/errors/string_lit_nil_trailer.res
+++ b/src/github.com/ebay/beam/query/parser/testdata/insert/errors/string_lit_nil_trailer.res
@@ -1,0 +1,1 @@
+parser: error parsing as legacy query: unable to parse query: line 1 column 37: expected string literal to not contain a nil

--- a/src/github.com/ebay/beam/query/parser/testdata/insert/errors/string_lit_nil_trailer.tsv
+++ b/src/github.com/ebay/beam/query/parser/testdata/insert/errors/string_lit_nil_trailer.tsv
@@ -1,0 +1,1 @@
+<Bob> rdfs:label "Bob's House\u0000"

--- a/src/github.com/ebay/beam/query/parser/testdata/legacy/literals/string_lit_nil_start.bql
+++ b/src/github.com/ebay/beam/query/parser/testdata/legacy/literals/string_lit_nil_start.bql
@@ -1,0 +1,1 @@
+#1 <Bob> rdfs:label "\u0000Bob's House"

--- a/src/github.com/ebay/beam/query/parser/testdata/legacy/literals/string_lit_nil_start.res
+++ b/src/github.com/ebay/beam/query/parser/testdata/legacy/literals/string_lit_nil_start.res
@@ -1,0 +1,5 @@
+Query:
+#1 <Bob> rdfs:label "\u0000Bob's House"
+
+Parsed:
+Error: unable to parse query: line 1 column 40: expected string literal to not contain a nil

--- a/src/github.com/ebay/beam/query/parser/testdata/legacy/literals/string_lit_nil_trailer.bql
+++ b/src/github.com/ebay/beam/query/parser/testdata/legacy/literals/string_lit_nil_trailer.bql
@@ -1,0 +1,1 @@
+#1 <Bob> rdfs:label "Bob's House\u0000"

--- a/src/github.com/ebay/beam/query/parser/testdata/legacy/literals/string_lit_nil_trailer.res
+++ b/src/github.com/ebay/beam/query/parser/testdata/legacy/literals/string_lit_nil_trailer.res
@@ -1,0 +1,5 @@
+Query:
+#1 <Bob> rdfs:label "Bob's House\u0000"
+
+Parsed:
+Error: unable to parse query: line 1 column 40: expected string literal to not contain a nil

--- a/src/github.com/ebay/beam/rpc/kgobject.go
+++ b/src/github.com/ebay/beam/rpc/kgobject.go
@@ -43,7 +43,8 @@ type KGObject struct {
 	//  LangID:		19 bytes [only for string]
 	//
 	// TypeBytes
-	//	String: 	the utf8 bytes of the string, no terminator, length is not encoded anywhere
+	//  String:     The utf8 bytes of the string, a terminating 0x00. length is not encoded anywhere.
+	//              The nil is to ensure correct ordering, its not used to determine the end of the string.
 	//  Float64:  	take the raw bits, invert them all if the value is negative, invert just the sign bit if its >= 0
 	//  Int64:  	8 bytes, the sign bit is flipped, which results in -MaxInt64 == 0(x8) & MaxInt64 = FF(x8) and 0 = 0x80 00 00 00 00 00 00 00
 	//  Timestamp: 	[year 2 bytes][month 1][day 1][hour 1][minutes 1][seconds 1][nanoseconds 4 bytes][precision 1 byte] normalized to GMT
@@ -168,7 +169,7 @@ type WriteOpts struct {
 // the 'opts' can be used to control exactly what is written
 func (o KGObject) WriteTo(buff *bytes.Buffer, opts WriteOpts) {
 	if opts.NoLangID && o.IsType(KtString) {
-		buff.WriteString(o.value[0 : len(o.value)-19])
+		buff.WriteString(o.value[0 : len(o.value)-20])
 		return
 	}
 	buff.WriteString(o.AsString())

--- a/src/github.com/ebay/beam/rpc/kgobject_accessors.go
+++ b/src/github.com/ebay/beam/rpc/kgobject_accessors.go
@@ -91,7 +91,7 @@ func (o KGObject) ValFloat64() float64 {
 // representation of the Object.
 func (o KGObject) ValString() string {
 	if o.ValueType() == KtString {
-		return string(o.value[1 : len(o.value)-19])
+		return string(o.value[1 : len(o.value)-20])
 	}
 	return ""
 }

--- a/src/github.com/ebay/beam/rpc/kgobject_new.go
+++ b/src/github.com/ebay/beam/rpc/kgobject_new.go
@@ -52,8 +52,9 @@ func KGObjectFromAPI(from api.KGObject) KGObject {
 // AString returns a new KGObject instance containing the supplied string and language ID.
 func AString(s string, langID uint64) KGObject {
 	b := new(kgObjectBuilder)
-	b.resetAndWriteType(KtString, 1+len(s)+19)
+	b.resetAndWriteType(KtString, 1+len(s)+20)
 	b.buff.WriteString(s)
+	b.buff.WriteByte(0)
 	appendUInt64(&b.buff, 19, langID)
 	return KGObject{b.buff.String()}
 }

--- a/src/github.com/ebay/beam/rpc/kgobject_test.go
+++ b/src/github.com/ebay/beam/rpc/kgobject_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 // if you add new cases here, put them in value order, as the test will verify
-// that the generated key of each subsequent item of the same type is lexographically
+// that the generated key of each subsequent item of the same type is lexicographically
 // after the previous one
 var orderedVals = []api.KGObject{
 	api.KGObject{},

--- a/src/github.com/ebay/beam/rpc/kgobject_test.go
+++ b/src/github.com/ebay/beam/rpc/kgobject_test.go
@@ -37,6 +37,8 @@ var orderedVals = []api.KGObject{
 	kgobject.AString("", 0),
 	kgobject.AString("Bob", 0),
 	kgobject.AString("Bob's House", 0),
+	kgobject.AString("Bob's House", 1),
+	kgobject.AString("Bob's Housf", 0),
 	kgobject.AString("Hello World", 0),
 	kgobject.AString("Hello World \u65e5\u672c\u8a9e", 0),
 	kgobject.AString("a", 0),
@@ -102,7 +104,7 @@ func Test_KGObjectRoundTrip(t *testing.T) {
 		assert.Equal(t, apiObj, decAPIObj, "failed to roundtrip kgobject %+v", apiObj)
 		if idx > 0 && (prevKey[0] == key[0]) {
 			cmp := bytes.Compare(prevKey, key)
-			assert.Equal(t, -1, cmp, "previous key expected to be smaller:\n  %d:%16x\n  %d:%16x\n  %d:%v\n  %d:%v", idx-1, prevKey, idx, key, idx-1, orderedVals[idx-1], idx, apiObj)
+			assert.Equal(t, -1, cmp, "previous key expected to be smaller:\n  %d:%16x\n  %d:%16x\n  %d:%v\n  %d:%v\n", idx-1, prevKey, idx, key, idx-1, orderedVals[idx-1], idx, apiObj)
 			assert.True(t, prevObj.Less(rpcObj))
 			assert.False(t, rpcObj.Less(prevObj))
 		}

--- a/src/github.com/ebay/beam/rpc/kgobject_test.go
+++ b/src/github.com/ebay/beam/rpc/kgobject_test.go
@@ -35,6 +35,8 @@ import (
 var orderedVals = []api.KGObject{
 	api.KGObject{},
 	kgobject.AString("", 0),
+	kgobject.AString("Bob", 0),
+	kgobject.AString("Bob's House", 0),
 	kgobject.AString("Hello World", 0),
 	kgobject.AString("Hello World \u65e5\u672c\u8a9e", 0),
 	kgobject.AString("a", 0),
@@ -98,7 +100,7 @@ func Test_KGObjectRoundTrip(t *testing.T) {
 		assert.NoError(t, err)
 		decAPIObj := decRPCObj.ToAPIObject()
 		assert.Equal(t, apiObj, decAPIObj, "failed to roundtrip kgobject %+v", apiObj)
-		if idx > 0 && (prevKey[0] == key[0]) && prevKey[0] != byte(KtString) { // TODO: skip string for now because of missing seperator beween the string & the langID
+		if idx > 0 && (prevKey[0] == key[0]) {
 			cmp := bytes.Compare(prevKey, key)
 			assert.Equal(t, -1, cmp, "previous key expected to be smaller:\n  %d:%16x\n  %d:%16x\n  %d:%v\n  %d:%v", idx-1, prevKey, idx, key, idx-1, orderedVals[idx-1], idx, apiObj)
 			assert.True(t, prevObj.Less(rpcObj))
@@ -206,14 +208,16 @@ func Test_WriteTo(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, kgo, r)
 	}
-	// currently the LangID is encoding into a 19 byte ascii string
+	// Currently the LangID is encoded into a trailing 19 byte ASCII string
+	// [utf8 bytes][0x00][19 char langID]
 	x := AString("Bob", 42)
 	b := bytes.Buffer{}
 	x.WriteTo(&b, WriteOpts{NoLangID: true})
+	assert.True(t, bytes.HasSuffix(b.Bytes(), []byte("Bob")))
 	assert.False(t, bytes.Contains(b.Bytes(), []byte("42")))
 	b2 := bytes.Buffer{}
 	x.WriteTo(&b2, WriteOpts{})
-	assert.Equal(t, b2.Len(), b.Len()+19)
+	assert.Equal(t, b2.Len(), b.Len()+20)
 }
 
 // This is an old test from when KGObject had a Hash method. The test has been


### PR DESCRIPTION
This adds a 0x00 between the string and the trailing languageID for
String KGObjects. This ensures that "Bob" and "Bob's House" are ordered
correctly. Previously this would be wrong because "Bob" would be
"Bob00000ID" and so would be sorted based on the first '0' after Bob.