### PR TITLE
Fix missing keys printing in db-scan. fixes #23

### DIFF
--- a/src/github.com/ebay/beam/tools/db-scan/main.go
+++ b/src/github.com/ebay/beam/tools/db-scan/main.go
@@ -121,14 +121,14 @@ func iter(db database.DB, cpu, trc string, printKeys bool, printBytes bool) *sta
 	if printKeys {
 		printer = func(k, _ []byte) {
 			if printBytes {
-				fmt.Printf("%s\n", k)
+				fmt.Printf("%v\n", k)
 				return
 			}
 			ik, err := keys.ParseKey(k)
 			if err != nil {
 				return
 			}
-			fk, ok := ik.(*keys.FactKey)
+			fk, ok := ik.(keys.FactKey)
 			if !ok {
 				return
 			}


### PR DESCRIPTION
`key.FactKey` changed from `*keys.FactKey` implementing `keys.Spec` to `keys.FactKey` implementing keys.Spec, and this is fallout from that. Some quality time with grep didn't show any other places with this issue.
This also changes the `-bytes` output, as the keys are changing to be binary.